### PR TITLE
BottomLineProgress.py：解决线程销毁bug

### DIFF
--- a/QPushButton/BottomLineProgress.py
+++ b/QPushButton/BottomLineProgress.py
@@ -10,7 +10,7 @@ Created on 2018年2月1日
 @description: 
 '''
 from random import randint
-import sys
+import sys, time
 
 from PyQt5.QtCore import QTimer, QThread, pyqtSignal
 from PyQt5.QtGui import QPainter, QColor, QPen
@@ -82,6 +82,7 @@ class PushButtonLine(QPushButton):
         self.loadingThread.valueChanged.disconnect(self.setPercent)
         self.loadingThread.terminate()
         self.loadingThread.deleteLater()
+        time.sleep(1)   #延迟等待deleteLater执行完毕
         del self.loadingThread
         self._percent = 0
         self._timer.stop()


### PR DESCRIPTION
before:
当运行BottomLineProgress.py时，会得到这个错误：
```
QThread: Destroyed while thread is still running
Aborted (core dumped)
```

这个pr解决这个小bug