### PR TITLE
Fix spelling error

### DIFF
--- a/QStackedWidget/LeftTabStacked.py
+++ b/QStackedWidget/LeftTabStacked.py
@@ -102,7 +102,7 @@ QLabel {
 
 if __name__ == '__main__':
     import sys
-    from PyQt5.QtWidgets import QApplicationr
+    from PyQt5.QtWidgets import QApplication
     app = QApplication(sys.argv)
     app.setStyleSheet(Stylesheet)
     w = LeftTabWidget()


### PR DESCRIPTION
There is a spelling error on line 105.

``` python
from PyQt5.QtWidgets import QApplicationr

# fix
from PyQt5.QtWidgets import QApplication
```